### PR TITLE
Fix code scanning alert no. 28: Incorrect suffix check

### DIFF
--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserFileSystem.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserFileSystem.js
@@ -208,6 +208,7 @@ export default class BrowserFileSystem {
     Object.keys(this._filesToDownload).forEach(filePath => {
       const upperCaseFilePath = filePath.toUpperCase();
       if (
+        upperCaseFilePath.indexOf(ext) !== -1 &&
         upperCaseFilePath.indexOf(ext) ===
         upperCaseFilePath.length - ext.length
       ) {


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-GDevelop/security/code-scanning/28](https://github.com/dsp-testing/alona-GDevelop/security/code-scanning/28)

To fix the problem, we need to ensure that the `indexOf` result is not -1 before comparing it to the expected position. This can be achieved by adding an explicit check for the -1 case. The best way to fix this without changing existing functionality is to modify the condition to include a check that `indexOf` does not return -1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
