### PR TITLE
Potential fix for code scanning alert no. 41: Incomplete string escaping or encoding

### DIFF
--- a/newIDE/app/scripts/lib/ExtensionReferenceGenerator.js
+++ b/newIDE/app/scripts/lib/ExtensionReferenceGenerator.js
@@ -247,7 +247,7 @@ const generateInstructionReferenceRowsText = ({
       instructionMetadata.getFullName() +
       '**  ' +
       '\n' +
-      instructionMetadata.getDescription().replace(/\n/, '  \n') +
+      instructionMetadata.getDescription().replace(/\n/g, '  \n') +
       '\n',
   };
 };


### PR DESCRIPTION
Potential fix for [https://github.com/dsp-testing/alona-GDevelop/security/code-scanning/41](https://github.com/dsp-testing/alona-GDevelop/security/code-scanning/41)

To fix the issue, the `replace` method should be updated to use a regular expression with the `g` (global) flag. This ensures that all occurrences of newline characters (`\n`) in the string are replaced with `  \n`. This change will correctly handle multi-line descriptions and ensure proper Markdown formatting.

The fix involves modifying line 250 to use `/\n/g` instead of `/\n/`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
